### PR TITLE
Add Axocoatl — open-source agentic runtime in Rust

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -595,5 +595,18 @@
     ],
     "openSource": "https://github.com/SidhuK/WardenApp",
     "dateAdded": "2025-01-14"
+  },
+  {
+    "slug": "Axocoatl",
+    "name": "Axocoatl",
+    "description": "Open-source agentic runtime in Rust — run supervised AI agents on your own hardware. Self-hosted, local-first, MCP-native; OpenRouter is one of its providers.",
+    "url": "https://axocoatl.ai",
+    "docs": "https://docs.axocoatl.ai",
+    "tags": [
+      "coding",
+      "productivity"
+    ],
+    "openSource": "https://github.com/axocoatl/axocoatl",
+    "dateAdded": "2026-06-04"
   }
 ]


### PR DESCRIPTION
Adds **Axocoatl**, an open-source agentic runtime written in Rust.

It runs persistent, supervised AI agents on your own hardware (self-hosted, local-first, zero telemetry), and supports **OpenRouter** as one of its six LLM providers via the OpenAI-compatible API — with proper `HTTP-Referer` / `X-Title` app attribution.

- Site: https://axocoatl.ai
- Repo: https://github.com/axocoatl/axocoatl (Apache-2.0)
- Docs: https://docs.axocoatl.ai

Entry added to `apps.json` following the existing schema (tags, openSource repo URL, dateAdded).