### PR TITLE
Add InternAgent to the app directory.

### DIFF
--- a/apps/internagent/app.yaml
+++ b/apps/internagent/app.yaml
@@ -1,0 +1,10 @@
+name: "InternAgent"
+description: "Open-source agentic framework for autonomous scientific discovery, deep research, and experiment iteration. Use OpenRouter as the model gateway with your own API key."
+url: "https://discovery.intern-ai.org.cn"
+docs: "https://github.com/InternScience/InternAgent/blob/main/docs/openrouter.md"
+tags:
+  - research
+  - productivity
+  - coding
+open_source: "https://github.com/InternScience/InternAgent"
+date_added: "2026-06-10"


### PR DESCRIPTION
Adds InternAgent to the Works with OpenRouter app directory.

InternAgent is an open-source agentic framework for autonomous scientific discovery, deep research, and experiment iteration. It now includes first-class OpenRouter provider support, allowing users to bring their own `OPENROUTER_API_KEY` and route model calls through OpenRouter.

## OpenRouter Support

- Added a dedicated `openrouter` provider in InternAgent
- Supports BYOK via `OPENROUTER_API_KEY`
- Uses the OpenRouter-compatible base URL: `https://openrouter.ai/api/v1`
- Includes setup docs: https://github.com/InternScience/InternAgent/blob/main/docs/openrouter.md

## Notability

InternAgent has public project traction and research presence, including a GitHub repository, project website, technical papers, and Hugging Face collection.
